### PR TITLE
added systemd service

### DIFF
--- a/wsl-ssh-agent-relay.service
+++ b/wsl-ssh-agent-relay.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=wsl-ssh-agent-relay
+After=sockets.target
+Requires=sockets.target
+
+[Service]
+Type=simple
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=wsl-ssh-agent-relay
+WorkingDirectory=/
+
+User=root
+Group=root
+
+Environment=WSL_AGENT_SSH_SOCK=/var/run/wsl-ssh-agent.sock
+Environment=RELAY_BIN=/usr/local/bin/npiperelay.exe
+
+ExecStart=/usr/bin/socat -d -d UNIX-LISTEN:"\"${WSL_AGENT_SSH_SOCK}\"",fork,mode=666 EXEC:"\"\'${RELAY_BIN}\' -ei -s \'//./pipe/openssh-ssh-agent\'\"",nofork
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Microsoft added support of systemd to WSL 0.67.6 and later.

To use systemd unit you need W11 and update wsl by `wsl --update`
Enable systemd by adding to /etc/wsl.conf
```
[boot]
systemd=true
```

Copy `wsl-ssh-agent-relay.service` to `/etc/systemd/system` folder.
```
systemctl daemon-reload
systemctl start wsl-ssh-agent-relay.service
systemctl enable wsl-ssh-agent-relay.service
```

Add `export SSH_AUTH_SOCK=/var/run/wsl-ssh-agent.sock` into `~/.bashrc`
